### PR TITLE
Configure Vercel static build output

### DIFF
--- a/joker-pursuit/vercel.json
+++ b/joker-pursuit/vercel.json
@@ -1,4 +1,13 @@
 {
+  "builds": [
+    {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "build"
+      }
+    }
+  ],
   "routes": [
     { "handle": "filesystem" },
     {
@@ -11,7 +20,7 @@
     },
     {
       "src": "/.*",
-      "dest": "/index.html"
+      "dest": "/"
     }
   ]
 }

--- a/joker-pursuit/vercel.json
+++ b/joker-pursuit/vercel.json
@@ -20,7 +20,7 @@
     },
     {
       "src": "/.*",
-      "dest": "/"
+      "dest": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- configure Vercel to build the React app as a static deployment
- keep custom websocket and API routes while ensuring the SPA falls back to the root document

## Testing
- not run (configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e46361a1248324a206328b7f6f8f7d