### PR TITLE
Configure Vercel build for client app

### DIFF
--- a/joker-pursuit/vercel.json
+++ b/joker-pursuit/vercel.json
@@ -1,8 +1,0 @@
-{
-  "rewrites": [
-    {
-      "source": "/((?!api|socket\\.io).*)",
-      "destination": "/index.html"
-    }
-  ]
-}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,19 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "joker-pursuit/package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "build"
+      }
+    }
+  ],
+  "routes": [
+    { "handle": "filesystem" },
+    {
+      "src": "^/(?!api|socket\\.io)(.*)$",
+      "dest": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- configure Vercel to build the Create React App client from the `joker-pursuit` subdirectory using the static-build runtime
- preserve the single page app routing fallback while allowing future socket.io endpoints to bypass the rewrite

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e49e795604832496cf9e6bb5530da6